### PR TITLE
Add router testing setup and sample test

### DIFF
--- a/docs/code-guidelines.md
+++ b/docs/code-guidelines.md
@@ -1,0 +1,3 @@
+# Code Guidelines
+
+- Prefer using `type` aliases over `interface` when defining TypeScript shapes.

--- a/packages/framework/bunfig.toml
+++ b/packages/framework/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./happydom.ts", "./testing-library.ts"]

--- a/packages/framework/happydom.ts
+++ b/packages/framework/happydom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();

--- a/packages/framework/matchers.d.ts
+++ b/packages/framework/matchers.d.ts
@@ -1,0 +1,8 @@
+import { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers";
+import { Matchers, AsymmetricMatchers } from "bun:test";
+
+declare module "bun:test" {
+  interface Matchers<T>
+    extends TestingLibraryMatchers<typeof expect.stringContaining, T> {}
+  interface AsymmetricMatchers extends TestingLibraryMatchers {}
+}

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,7 +1,19 @@
 {
   "name": "framework",
+  "type": "module",
+  "exports": {
+    "./build": "./build.ts",
+    "./runtime": "./runtime/index.ts"
+  },
+  "scripts": {
+    "test": "bun test"
+  },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "@happy-dom/global-registrator": "latest",
+    "@testing-library/react": "latest",
+    "@testing-library/dom": "latest",
+    "@testing-library/jest-dom": "latest"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/packages/framework/runtime/index.ts
+++ b/packages/framework/runtime/index.ts
@@ -1,0 +1,1 @@
+export * from "./router";

--- a/packages/framework/runtime/router.test.tsx
+++ b/packages/framework/runtime/router.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { Router, Link } from "./router";
+
+function Home() {
+  return (
+    <div>
+      Home <Link to="/about">About</Link>
+    </div>
+  );
+}
+
+function About() {
+  return <div>About</div>;
+}
+
+const routes = [
+  { path: "/", component: Home },
+  { path: "/about", component: About },
+];
+
+test("navigates between routes", () => {
+  render(<Router routes={routes} />);
+  expect(screen.getByText("Home")).toBeInTheDocument();
+  fireEvent.click(screen.getByText("About"));
+  expect(screen.getByText("About")).toBeInTheDocument();
+});

--- a/packages/framework/runtime/router.tsx
+++ b/packages/framework/runtime/router.tsx
@@ -1,0 +1,140 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+
+export type Route = {
+  path: string;
+  component: React.ComponentType<any>;
+};
+
+type RouterState = {
+  url: URL;
+  search: Record<string, string>;
+  params: Record<string, string>;
+};
+
+type RouterContextValue = RouterState & {
+  navigate: (to: string, options?: { replace?: boolean }) => void;
+};
+
+const RouterContext = React.createContext<RouterContextValue | undefined>(
+  undefined,
+);
+
+function parseSearch(url: URL): Record<string, string> {
+  const search: Record<string, string> = {};
+  url.searchParams.forEach((value, key) => {
+    search[key] = value;
+  });
+  return search;
+}
+
+function matchRoute(pathname: string, routes: Route[]) {
+  for (const route of routes) {
+    const names: string[] = [];
+    const pattern = route.path
+      .split("/")
+      .map((segment) => {
+        if (segment.startsWith(":")) {
+          names.push(segment.slice(1));
+          return "([^/]+)";
+        }
+        return segment.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+      })
+      .join("/");
+    const regex = new RegExp(`^${pattern}$`);
+    const match = pathname.match(regex);
+    if (match) {
+      const params: Record<string, string> = {};
+      names.forEach((name, i) => {
+        params[name] = decodeURIComponent(match[i + 1]);
+      });
+      return { component: route.component, params };
+    }
+  }
+  return null;
+}
+
+function createState(url: URL, routes: Route[]): RouterState {
+  const match = matchRoute(url.pathname, routes);
+  return {
+    url,
+    search: parseSearch(url),
+    params: match?.params ?? {},
+  };
+}
+
+export type RouterProps = {
+  routes: Route[];
+  children?: React.ReactNode;
+};
+
+export function Router({ routes, children }: RouterProps) {
+  const [state, setState] = useState(() =>
+    createState(new URL(window.location.href), routes),
+  );
+
+  const navigate = useCallback(
+    (to: string, options?: { replace?: boolean }) => {
+      const url = new URL(to, window.location.origin);
+      if (options?.replace) {
+        window.history.replaceState(null, "", url.toString());
+      } else {
+        window.history.pushState(null, "", url.toString());
+      }
+      setState(createState(url, routes));
+    },
+    [routes],
+  );
+
+  useEffect(() => {
+    const handler = () => {
+      setState(createState(new URL(window.location.href), routes));
+    };
+    window.addEventListener("popstate", handler);
+    return () => window.removeEventListener("popstate", handler);
+  }, [routes]);
+
+  const value = useMemo<RouterContextValue>(
+    () => ({ ...state, navigate }),
+    [state, navigate],
+  );
+
+  const match = matchRoute(state.url.pathname, routes);
+  const Component = match?.component ?? React.Fragment;
+
+  return (
+    <RouterContext.Provider value={value}>
+      <Component />
+      {children}
+    </RouterContext.Provider>
+  );
+}
+
+export function useNavigate() {
+  const ctx = React.useContext(RouterContext);
+  if (!ctx) throw new Error("useNavigate must be used within Router");
+  return ctx.navigate;
+}
+
+export function useRouterState() {
+  const ctx = React.useContext(RouterContext);
+  if (!ctx) throw new Error("useRouterState must be used within Router");
+  const { url, search, params } = ctx;
+  return { url, search, params };
+}
+
+export type LinkProps = Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href"
+> & {
+  to: string;
+  replace?: boolean;
+};
+
+export function Link({ to, replace, ...props }: LinkProps) {
+  const navigate = useNavigate();
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    navigate(to, { replace });
+  };
+  return <a href={to} onClick={handleClick} {...props} />;
+}

--- a/packages/framework/testing-library.ts
+++ b/packages/framework/testing-library.ts
@@ -1,0 +1,9 @@
+import { afterEach, expect } from "bun:test";
+import { cleanup } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+
+expect.extend(matchers);
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- document TypeScript style
- add build and runtime exports for the framework package
- implement a minimal router and expose it from the runtime index
- set up React Testing Library with Bun for framework package
- provide a simple navigation test for the router

## Testing
- `bun run fmt`
- `bun run typecheck` *(fails: Script not found)*
- `cd apps/web && bun run test` *(fails: No such file or directory)*
- `cd packages/framework && bun test` *(fails: Cannot find module '@happy-dom/global-registrator')*

------
https://chatgpt.com/codex/tasks/task_e_6862105d1bc48333aa0cb33243ed8f29