### PR TITLE
Add Vercel style router params

### DIFF
--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -148,3 +148,15 @@ Run with: `bun scripts/build.ts`
 - **Bun** - Used for building and bundling
 - **Node.js** - For file system operations
 - **src/index.html** - Required entry point file
+
+## Runtime Router
+
+The runtime includes a minimal React router for client-side navigation.
+
+### Supported features
+
+- Static routes (e.g. `/about`)
+- Vercel-style dynamic routes using `[param]` segments
+- Query string parsing via `useRouterState`
+- `<Link>` component and `useNavigate` for navigation
+

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@happy-dom/global-registrator": "latest",
+    "@happy-dom/global-registrator": "18.0.1",
     "@testing-library/react": "latest",
     "@testing-library/dom": "latest",
     "@testing-library/jest-dom": "latest"

--- a/packages/framework/runtime/router.test.tsx
+++ b/packages/framework/runtime/router.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
-import { Router, Link } from "./router";
+import { Router, Link, useRouterState } from "./router";
 
 function Home() {
   return (
@@ -24,4 +24,32 @@ test("navigates between routes", () => {
   expect(screen.getByText("Home")).toBeInTheDocument();
   fireEvent.click(screen.getByText("About"));
   expect(screen.getByText("About")).toBeInTheDocument();
+});
+
+function HomeWithParams() {
+  return (
+    <div>
+      Home <Link to="/todos/123?foo=bar">Todo</Link>
+    </div>
+  );
+}
+
+function Todo() {
+  const { params, search } = useRouterState();
+  return (
+    <div>
+      Todo {params.id} {search.foo}
+    </div>
+  );
+}
+
+const paramRoutes = [
+  { path: "/", component: HomeWithParams },
+  { path: "/todos/[id]", component: Todo },
+];
+
+test("parses params and query string", () => {
+  render(<Router routes={paramRoutes} />);
+  fireEvent.click(screen.getByText("Todo"));
+  expect(screen.getByText("Todo 123 bar")).toBeInTheDocument();
 });

--- a/packages/framework/runtime/router.tsx
+++ b/packages/framework/runtime/router.tsx
@@ -37,6 +37,11 @@ function matchRoute(pathname: string, routes: Route[]) {
           names.push(segment.slice(1));
           return "([^/]+)";
         }
+        const bracket = segment.match(/^\[(.+)\]$/);
+        if (bracket) {
+          names.push(bracket[1]);
+          return "([^/]+)";
+        }
         return segment.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
       })
       .join("/");


### PR DESCRIPTION
## Summary
- support `[param]` segments in the router
- document runtime router features
- test param parsing and search handling
- add Happy DOM registrator dependency to framework package
- remove registrator from root package.json

## Testing
- `bun test` *(fails: Cannot find module 'react/jsx-dev-runtime')*


------
https://chatgpt.com/codex/tasks/task_e_686214d02f5c8333998a63b9db41d82f