### PR TITLE
Add router documentation and demo routes

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,8 +1,63 @@
-export function App() {
+import React from "react";
+import { Router, Link, useRouterState } from "framework/runtime";
+
+function Nav() {
+  return (
+    <nav>
+      <Link to="/">Home</Link> | <Link to="/about">About</Link> | {" "}
+      <Link to="/users/42">User</Link>
+    </nav>
+  );
+}
+
+function Home() {
   return (
     <div className="app">
       <h1>Bun + React</h1>
+      <h2>Home</h2>
+      <Nav />
     </div>
+  );
+}
+
+function About() {
+  return (
+    <div className="app">
+      <h1>Bun + React</h1>
+      <h2>About</h2>
+      <Nav />
+    </div>
+  );
+}
+
+function User() {
+  const { params } = useRouterState();
+  return (
+    <div className="app">
+      <h1>Bun + React</h1>
+      <h2>User {params.id}</h2>
+      <Nav />
+    </div>
+  );
+}
+
+const routes = [
+  { path: "/", component: Home },
+  { path: "/about", component: About },
+  { path: "/users/[id]", component: User },
+];
+
+function RouterLogger() {
+  const state = useRouterState();
+  console.log("router state", state);
+  return null;
+}
+
+export function App() {
+  return (
+    <Router routes={routes}>
+      <RouterLogger />
+    </Router>
   );
 }
 

--- a/packages/framework/runtime/ROUTER.md
+++ b/packages/framework/runtime/ROUTER.md
@@ -1,0 +1,67 @@
+# Runtime Router Usage
+
+The runtime exports a very small client side router for React applications. It
+is intended for demos and testing and only implements a subset of typical router
+features.
+
+## Components and Hooks
+
+- `Router` – wraps the application and renders the component that matches the
+  current `window.location`.
+- `Link` – navigates to a new route on click without reloading the page.
+- `useNavigate()` – programmatic navigation helper.
+- `useRouterState()` – exposes `{ url, search, params }` derived from the
+  current location.
+
+## Defining Routes
+
+Routes are declared as an array of objects with a `path` and React `component`:
+
+```tsx
+const routes = [
+  { path: '/', component: Home },
+  { path: '/about', component: About },
+  { path: '/users/[id]', component: User },
+];
+```
+
+Paths can be static or contain dynamic segments using either `[param]` or
+`:param` syntax.
+
+## Usage Example
+
+```tsx
+import { Router, Link, useRouterState } from 'framework/runtime';
+
+function Home() {
+  return (
+    <div>
+      <h2>Home</h2>
+      <Link to="/about">About</Link>
+    </div>
+  );
+}
+
+function About() {
+  const { url } = useRouterState();
+  return (
+    <div>
+      <h2>About</h2>
+      <p>Current URL: {url.pathname}</p>
+      <Link to="/">Home</Link>
+    </div>
+  );
+}
+
+const routes = [
+  { path: '/', component: Home },
+  { path: '/about', component: About },
+];
+
+export default function App() {
+  return <Router routes={routes} />;
+}
+```
+
+`Router` listens for `popstate` events so browser navigation works as expected.
+When no route matches the current path, nothing is rendered.


### PR DESCRIPTION
## Summary
- document runtime router usage
- integrate router into the app with demo routes and links
- log router state to the console

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_686220e88240833380258cf5f69bd453