### PR TITLE
Add framework router dep in app

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,12 +13,12 @@
   "dependencies": {
     "react": "^19",
     "react-dom": "^19",
-    "vercel-experiments-ui": "workspace:*"
+    "vercel-experiments-ui": "workspace:*",
+    "framework": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "latest",
     "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "framework": "workspace:*"
+    "@types/react-dom": "^19"
   }
 }


### PR DESCRIPTION
## Summary
- add framework package to app dependencies so `framework/router` can be imported at runtime

## Testing
- `bun test` in `packages/framework`


------
https://chatgpt.com/codex/tasks/task_e_686228945568833382fbe17c6d9f6cec