### PR TITLE
Add real tailwind integration in build tests

### DIFF
--- a/packages/framework/build.test.ts
+++ b/packages/framework/build.test.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, mkdir, writeFile, rm, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+async function loadBuild() {
+  return (await import("./build")) as typeof import("./build");
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function withTempDir(fn: (dir: string) => Promise<void>) {
+  return async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "fw-build-"));
+    const cwd = process.cwd();
+    try {
+      process.chdir(dir);
+      await fn(dir);
+    } finally {
+      // remove build artifacts if they were created
+      await rm(path.join(dir, ".vercel"), { recursive: true, force: true });
+      process.chdir(cwd);
+      await rm(dir, { recursive: true, force: true });
+    }
+  };
+}
+
+const htmlContent = `<!doctype html>
+<html><head></head><body><script type="module" src="./index.ts"></script></body></html>`;
+const tsContent = `console.log('hello');`;
+
+test(
+  "build creates vercel output and copies public files",
+  withTempDir(async (dir) => {
+    await mkdir(path.join(dir, "src"));
+    await writeFile(path.join(dir, "src/index.html"), htmlContent);
+    await writeFile(path.join(dir, "src/index.ts"), tsContent);
+    await mkdir(path.join(dir, "public"));
+    await writeFile(path.join(dir, "public/test.txt"), "static");
+
+    const { build } = await loadBuild();
+    const result = await build();
+    expect(result.success).toBe(true);
+
+    const outBase = path.join(dir, ".vercel/output");
+    expect(await fileExists(path.join(outBase, "config.json"))).toBe(true);
+    expect(
+      await fileExists(path.join(outBase, "static/index.html"))
+    ).toBe(true);
+    expect(await fileExists(path.join(outBase, "static/tailwind.css"))).toBe(
+      true,
+    );
+    expect(await fileExists(path.join(outBase, "static/test.txt"))).toBe(true);
+  }),
+);
+
+test(
+  "warns when public directory is missing",
+  withTempDir(async (dir) => {
+    await mkdir(path.join(dir, "src"));
+    await writeFile(path.join(dir, "src/index.html"), htmlContent);
+    await writeFile(path.join(dir, "src/index.ts"), tsContent);
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg?: any) => {
+      warnings.push(String(msg));
+    };
+    const { build } = await loadBuild();
+    const result = await build();
+    console.warn = origWarn;
+
+    expect(result.success).toBe(true);
+    expect(warnings.some((m) => m.includes("Public directory not found"))).toBe(
+      true,
+    );
+  }),
+);
+
+test(
+  "throws when src directory is missing",
+  withTempDir(async () => {
+    const { build } = await loadBuild();
+    await expect(build()).rejects.toThrow("Source directory not found");
+  }),
+);
+
+test(
+  "throws when entry point is missing",
+  withTempDir(async (dir) => {
+    await mkdir(path.join(dir, "src"));
+    const { build } = await loadBuild();
+    await expect(build()).rejects.toThrow("Entry point not found");
+  }),
+);

--- a/packages/framework/build.ts
+++ b/packages/framework/build.ts
@@ -2,7 +2,7 @@ import { $ } from "bun";
 import { mkdir, access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { compile } from "tailwindcss/dist/lib.mjs";
+import { compile } from "tailwindcss";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const uiStylesPath = path.resolve(__dirname, "../ui/styles/globals.css");


### PR DESCRIPTION
## Summary
- remove tailwind compile mock and import the real package
- update build.ts to import from `tailwindcss`
- run framework tests to ensure tailwind compilation works

## Testing
- `cd packages/framework && bun test`


------
https://chatgpt.com/codex/tasks/task_e_686347fe6d208333937a34934fc694d4