### PR TITLE
Fix Tailwind build and add hashed CSS

### DIFF
--- a/packages/app/src/entry.server.tsx
+++ b/packages/app/src/entry.server.tsx
@@ -13,14 +13,20 @@ try {
   console.warn(
     "Warning: Could not read manifest.json, falling back to development mode",
   );
-  manifest = { "entry.client.tsx": "./entry.client.tsx" };
+  manifest = {
+    "entry.client.tsx": "./entry.client.tsx",
+    "tailwind.css": "./tailwind.css",
+  };
 }
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const clientScriptSrc = manifest["entry.client.tsx"] || "./entry.client.tsx";
+  const cssHref = manifest["tailwind.css"] || "./tailwind.css";
   const html =
     "<!doctype html>" +
-    renderToString(<Root url={url} clientScriptSrc={clientScriptSrc} />);
+    renderToString(
+      <Root url={url} clientScriptSrc={clientScriptSrc} cssHref={cssHref} />,
+    );
   return new Response(html, { headers: { "Content-Type": "text/html" } });
 }

--- a/packages/app/src/root.tsx
+++ b/packages/app/src/root.tsx
@@ -4,9 +4,11 @@ import { routes } from "./App";
 export function Root({
   url,
   clientScriptSrc = "./entry.client.tsx",
+  cssHref = "./tailwind.css",
 }: {
   url?: string | URL;
   clientScriptSrc?: string;
+  cssHref?: string;
 }) {
   return (
     <html lang="en">
@@ -14,7 +16,7 @@ export function Root({
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Bun + React</title>
-        <link rel="stylesheet" href="./tailwind.css" />
+        <link rel="stylesheet" href={cssHref} />
       </head>
       <body>
         <Router routes={routes} url={url} />

--- a/packages/framework/build.test.ts
+++ b/packages/framework/build.test.ts
@@ -71,10 +71,10 @@ test(
     const manifestPath = path.join(outBase, "static/manifest.json");
     expect(await fileExists(path.join(outBase, "config.json"))).toBe(true);
     expect(await fileExists(manifestPath)).toBe(true);
-    expect(await fileExists(path.join(outBase, "static/tailwind.css"))).toBe(
-      true,
-    );
     const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    const cssFile = manifest["tailwind.css"]?.replace(/^\.\/?/, "");
+    expect(cssFile).toBeDefined();
+    expect(await fileExists(path.join(outBase, "static", cssFile))).toBe(true);
     const clientFile = manifest["entry.client.tsx"]?.replace(/^\.\/?/, "");
     expect(clientFile).toBeDefined();
     expect(await fileExists(path.join(outBase, "static", clientFile))).toBe(


### PR DESCRIPTION
## Summary
- fix Tailwind compile error by providing `loadModule`
- output hashed `tailwind.css` and add to manifest
- teach server/Root components to read hashed CSS path
- update build tests for hashed css filename

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68647294e2388333a6ac8be1d8ffb7d8