### PR TITLE
Fix hashed CSS in marketing build

### DIFF
--- a/packages/marketing/src/entry.server.tsx
+++ b/packages/marketing/src/entry.server.tsx
@@ -13,13 +13,19 @@ try {
   console.warn(
     "Warning: Could not read manifest.json, falling back to development mode",
   );
-  manifest = { "entry.client.tsx": "./entry.client.tsx" };
+  manifest = {
+    "entry.client.tsx": "./entry.client.tsx",
+    "tailwind.css": "./tailwind.css",
+  };
 }
 
 export async function GET() {
   const clientScriptSrc = manifest["entry.client.tsx"] || "./entry.client.tsx";
+  const cssHref = manifest["tailwind.css"] || "./tailwind.css";
   const html =
     "<!doctype html>" +
-    renderToString(<Root clientScriptSrc={clientScriptSrc} />);
+    renderToString(
+      <Root clientScriptSrc={clientScriptSrc} cssHref={cssHref} />,
+    );
   return new Response(html, { headers: { "Content-Type": "text/html" } });
 }

--- a/packages/marketing/src/root.tsx
+++ b/packages/marketing/src/root.tsx
@@ -2,8 +2,10 @@ import { App } from "./App";
 
 export function Root({
   clientScriptSrc = "./entry.client.tsx",
+  cssHref = "./tailwind.css",
 }: {
   clientScriptSrc?: string;
+  cssHref?: string;
 }) {
   return (
     <html lang="en">
@@ -11,7 +13,7 @@ export function Root({
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Bun + React</title>
-        <link rel="stylesheet" href="./tailwind.css" />
+        <link rel="stylesheet" href={cssHref} />
       </head>
       <body>
         <App />


### PR DESCRIPTION
## Summary
- pass `cssHref` to marketing root to pick up hashed Tailwind output
- read `tailwind.css` from manifest in marketing server entry

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_686476f856ec8333aa0d81db0894beb0