### PR TITLE
Fix template path resolution

### DIFF
--- a/packages/app/src/entry.server.tsx
+++ b/packages/app/src/entry.server.tsx
@@ -6,7 +6,7 @@ import { routes } from "./App";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const templatePath = resolve(__dirname, "../static/index.html");
+  const templatePath = resolve(__dirname, "index.html");
   let html = await readFile(templatePath, "utf8");
   const appHtml = renderToString(<Router routes={routes} url={url} />);
   html = html.replace('<div id="app"></div>', `<div id="app">${appHtml}</div>`);

--- a/packages/framework/build.ts
+++ b/packages/framework/build.ts
@@ -87,6 +87,7 @@ export async function build() {
     sourcemap: "linked",
     target: "browser",
     minify: true,
+    publicPath: "/static/",
     define: {
       "process.env.NODE_ENV": '"production"',
     },
@@ -128,6 +129,13 @@ export async function build() {
     JSON.stringify(serverConfig, null, 2),
   );
   console.log(`✅ Built SSR function to ${funcDir}`);
+
+  // Move the built HTML template next to the server function
+  try {
+    await $`mv ${path.join(staticOutputDir, "index.html")} ${path.join(funcDir, "index.html")}`;
+  } catch (error) {
+    console.warn(`⚠️  Failed to move index.html: ${error}`);
+  }
 
   // Create config.json for Vercel Build Output Configuration
   const configPath = path.join(outputDir, "config.json");


### PR DESCRIPTION
## Summary
- move HTML template into the serverless function directory during build
- bundle assets with `/static/` prefix
- simplify server entry template path

## Testing
- `bun run dev` *(from `packages/app`)*
- `bun run build` *(from `packages/app`)*


------
https://chatgpt.com/codex/tasks/task_e_6864c2929f5c8333b8043db0766f5681