### PR TITLE
Fix server template path resolution

### DIFF
--- a/packages/app/src/entry.server.tsx
+++ b/packages/app/src/entry.server.tsx
@@ -1,12 +1,12 @@
 import { renderToString } from "react-dom/server";
 import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { Router } from "framework/runtime";
 import { routes } from "./App";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const templatePath = resolve(__dirname, "index.html");
+  const templatePath = fileURLToPath(new URL("./index.html", import.meta.url));
   let html = await readFile(templatePath, "utf8");
   const appHtml = renderToString(<Router routes={routes} url={url} />);
   html = html.replace('<div id="app"></div>', `<div id="app">${appHtml}</div>`);

--- a/packages/marketing/src/entry.server.tsx
+++ b/packages/marketing/src/entry.server.tsx
@@ -1,10 +1,12 @@
 import { renderToString } from "react-dom/server";
 import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import App from "./App";
 
 export async function GET() {
-  const templatePath = resolve(__dirname, "../static/index.html");
+  const templatePath = fileURLToPath(
+    new URL("../static/index.html", import.meta.url),
+  );
   let html = await readFile(templatePath, "utf8");
   const appHtml = renderToString(<App />);
   html = html.replace('<div id="app"></div>', `<div id="app">${appHtml}</div>`);


### PR DESCRIPTION
## Summary
- resolve server templates using `import.meta.url` so builds can locate index.html after bundling

## Testing
- `bun test` *(fails: expect(received).toBe(expected))*

------
https://chatgpt.com/codex/tasks/task_e_6864c7a3e47c833391f58f2fb63c538d