### PR TITLE
Fix server template path resolution

### DIFF
--- a/packages/app/src/entry.server.tsx
+++ b/packages/app/src/entry.server.tsx
@@ -1,12 +1,19 @@
 import { renderToString } from "react-dom/server";
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { readFile, readdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { Router } from "framework/runtime";
 import { routes } from "./App";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const templatePath = resolve(__dirname, "index.html");
+  const templatePath = fileURLToPath(new URL("./index.html", import.meta.url));
+
+  const dir = fileURLToPath(new URL("./", import.meta.url));
+  console.log("📂 Server cwd", process.cwd());
+  console.log("📂 Server dir", dir);
+  console.log("📂 Dir contents", await readdir(dir));
+  console.log("📄 Template path", templatePath);
+
   let html = await readFile(templatePath, "utf8");
   const appHtml = renderToString(<Router routes={routes} url={url} />);
   html = html.replace('<div id="app"></div>', `<div id="app">${appHtml}</div>`);

--- a/packages/framework/build.ts
+++ b/packages/framework/build.ts
@@ -1,9 +1,11 @@
 import { $ } from "bun";
 import { mkdir, access, writeFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
 export async function build() {
   const rootDir = process.cwd();
+  console.log(`🛠️  Starting build in ${rootDir}`);
   const publicDir = "public";
   const srcDir = "src";
   const htmlEntry = "index.html";
@@ -55,6 +57,8 @@ export async function build() {
   // Create output directories
   await mkdir(staticOutputDir, { recursive: true });
   console.log(`✅ Created output directory: ${staticOutputDir}`);
+  console.log("📂 Initial contents of output directory:");
+  await $`ls -al ${staticOutputDir}`;
 
   // Copy static files from public/ to output directory (if public dir exists)
   if (hasPublicDir) {
@@ -63,6 +67,8 @@ export async function build() {
       console.log(
         `✅ Copied static files from ${publicDir}/ to ${staticOutputDir}`,
       );
+      console.log("📂 Contents after copying public files:");
+      await $`ls -al ${staticOutputDir}`;
     } catch (error) {
       console.warn(`⚠️  Failed to copy files from ${publicDir}/: ${error}`);
     }
@@ -96,6 +102,8 @@ export async function build() {
   if (!htmlOutput.success) {
     throw new Error("Client build failed");
   }
+  console.log("✅ Client build completed");
+  await $`ls -al ${staticOutputDir}`;
 
   if (cleanupTailwind) {
     await rm(tailwindPath);
@@ -130,11 +138,24 @@ export async function build() {
   );
   console.log(`✅ Built SSR function to ${funcDir}`);
 
+  console.log(`📂 Contents of static output directory before move:`);
+  await $`ls -al ${staticOutputDir}`;
+
   // Move the built HTML template next to the server function
   try {
     await $`mv ${path.join(staticOutputDir, "index.html")} ${path.join(funcDir, "index.html")}`;
+    console.log("✅ Moved index.html to function directory");
   } catch (error) {
     console.warn(`⚠️  Failed to move index.html: ${error}`);
+  }
+
+  console.log(`📂 Contents of ${funcDir} after move:`);
+  await $`ls -al ${funcDir}`;
+
+  if (existsSync(path.join(funcDir, "index.html"))) {
+    console.log("✅ Verified index.html present in function directory");
+  } else {
+    console.warn("❌ index.html not found in function directory");
   }
 
   // Create config.json for Vercel Build Output Configuration

--- a/packages/marketing/src/entry.server.tsx
+++ b/packages/marketing/src/entry.server.tsx
@@ -1,10 +1,12 @@
 import { renderToString } from "react-dom/server";
 import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import App from "./App";
 
 export async function GET() {
-  const templatePath = resolve(__dirname, "../static/index.html");
+  const templatePath = fileURLToPath(
+    new URL("../static/index.html", import.meta.url),
+  );
   let html = await readFile(templatePath, "utf8");
   const appHtml = renderToString(<App />);
   html = html.replace('<div id="app"></div>', `<div id="app">${appHtml}</div>`);


### PR DESCRIPTION
## Summary
- resolve server templates using `import.meta.url` so builds can locate index.html after bundling
- add logs in build script to verify index.html is moved
- output current directory contents in the server handler for debugging

## Testing
- `bun test` *(fails: expect(received).toBe(expected))*

------
https://chatgpt.com/codex/tasks/task_e_6864c7a3e47c833391f58f2fb63c538d